### PR TITLE
feat: Introduced a new function called provideStore() which accepts a already created Redux store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,63 @@
+# 3.2.0
+
+### Features
+
+* Added a `provideStore()` function which lets you pass in a already created
+store. It can be used as this:
+
+Create your store:
+```typescript
+// store.ts
+
+import {
+  applyMiddleware,
+  Store,
+  combineReducers,
+  compose,
+  createStore
+} from 'redux';
+import thunk from 'redux-thunk';
+import reduxLogger from 'redux-logger';
+
+import {myReducer} from './reducers/my-reducer';
+
+const rootReducer = combineReducers({
+  myReducer,
+});
+
+export const store = createStore(
+  rootReducer,
+  compose(
+    applyMiddleware(
+      thunk,
+      reduxLogger
+    )
+  )
+) as Store
+```
+
+Create your App and call `provideStore` with your newly store:
+```typescript
+// app.ts
+
+import { NgRedux } from 'ng2-redux';
+import { store } from './store.ts';
+
+interface IAppState {
+  // ...
+};
+@Component({
+  // ... etc.
+})
+class App {
+  constructor(private ngRedux: NgRedux) {
+    this.ngRedux.provideStore(store);
+  }
+
+  // ...
+}
+```
+
 # 3.1.0
 
 ### Features
@@ -11,7 +71,7 @@ an observable.
 ```js
 import { is } from 'immutablejs'
 
-export class SomeComponent { 
+export class SomeComponent {
   @select(n=n.some.selector, is) someSelector$: Observable<any>
 }
 
@@ -29,7 +89,7 @@ export class SomeComponent {
 ### Features
 
 #### Select Decorator
-This release introduces the new decorator interface. You can now use 
+This release introduces the new decorator interface. You can now use
 `@select`  to create an observable from a slice of store state.
 
 See 'the select pattern' in [README.md](README.md#the-select-pattern)
@@ -132,9 +192,9 @@ community: `redux-logger` and `redux-localstorage`.
 
 ### Features
 
-* **Type definitions**: 
+* **Type definitions**:
   * Ported to typescript
-  * Supports typed stores / reducers 
+  * Supports typed stores / reducers
   * Uses offical Redux type definitions
 * **Type Injectable**:
   * Able to inject `NgRedux` into your component by type, and not need `@Inject('ngRedux')`
@@ -142,7 +202,7 @@ community: `redux-logger` and `redux-localstorage`.
 
 ```typescript
 import { NgRedux } from 'ng2-redux';
-// ... 
+// ...
 export class MyComponent {
   constructor(private ngRedux: NgRedux) {}
 }
@@ -181,7 +241,7 @@ export class MyComponent implements OnInit {
   person$: Observable<Map<string,any>>;
 
   constructor(private ngRedux: ngRedux) {
-    // even if the reference of the object has changed, 
+    // even if the reference of the object has changed,
     // if the data is the same - it wont be treated as a change
     this.person$ = this.ngRedux.select(state=>state.people.get(0),is);
   }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ import {
 import thunk from 'redux-thunk';
 import reduxLogger from 'redux-logger';
 
-import {myReducer} from './reducers/my-reducer';
+import { myReducer } from './reducers/my-reducer';
 
 const rootReducer = combineReducers({
   myReducer,
@@ -36,7 +36,7 @@ export const store = createStore(
 ) as Store
 ```
 
-Create your App and call `provideStore` with your newly store:
+Create your App and call `provideStore` with your newly created store:
 ```typescript
 // app.ts
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ import {
 import thunk from 'redux-thunk';
 import reduxLogger from 'redux-logger';
 
-import {myReducer} from './reducers/my-reducer';
+import { myReducer } from './reducers/my-reducer';
 
 const rootReducer = combineReducers({
   myReducer,
@@ -104,7 +104,7 @@ export const store = createStore(
 ) as Store
 ```
 
-Create your App and call `provideStore` with your newly store:
+Create your App and call `provideStore` with your newly created store:
 ```typescript
 // app.ts
 

--- a/README.md
+++ b/README.md
@@ -546,7 +546,7 @@ has been used this cannot be used.
 
 __Arguments:__
 
-* `rootReducer` \(*Store*): Your app's store.
+* `store` \(*Store*): Your app's store.
 
 ### select(key | function,[comparer]) => Observable
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,62 @@ class App {
 }
 ```
 
+Or if you prefer to create the Redux store yourself you can do that and use the
+`provideStore()` function instead.
+
+Create your store:
+```typescript
+// store.ts
+
+import {
+  applyMiddleware,
+  Store,
+  combineReducers,
+  compose,
+  createStore
+} from 'redux';
+import thunk from 'redux-thunk';
+import reduxLogger from 'redux-logger';
+
+import {myReducer} from './reducers/my-reducer';
+
+const rootReducer = combineReducers({
+  myReducer,
+});
+
+export const store = createStore(
+  rootReducer,
+  compose(
+    applyMiddleware(
+      thunk,
+      reduxLogger
+    )
+  )
+) as Store
+```
+
+Create your App and call `provideStore` with your newly store:
+```typescript
+// app.ts
+
+import { NgRedux } from 'ng2-redux';
+import { store } from './store.ts';
+
+interface IAppState {
+  // ...
+};
+@Component({
+  // ... etc.
+})
+class App {
+  constructor(private ngRedux: NgRedux) {
+    this.ngRedux.provideStore(store);
+  }
+
+  // ...
+}
+```
+
 Now your Angular 2 app has been reduxified!
 
 ## Usage
@@ -85,19 +141,19 @@ preferred approach to accessing store data in Angular 2.
 
 #### The @select decorator
 
-The `@select` decorator can be added to the property of any class or angular 
+The `@select` decorator can be added to the property of any class or angular
 component/injectable. It will turn the property into an observable which observes
 the Redux Store value which is selected by the decorator's parameter.
 
 The decorator expects to receive a `string`, an array of `string`s, a `function` or no
-parameter at all. 
+parameter at all.
 
 - If a `string` is passed the `@select` decorator will attempt to observe a store
 property whose name matches the `string`.
 - If an array of strings is passed, the decorator will attempt to match that path
 through the store (similar to `immutableJS`'s `getIn`).
 - If a `function` is passed the `@select` decorator will attempt to use that function
-as a selector on the RxJs observable. 
+as a selector on the RxJs observable.
 - If nothing is passed then the `@select` decorator will attempt to use the name of the class property to find a matching value in the Redux store. Note that a utility is in place here where any $ characters will be ignored from the class property's name.
 
 ```typescript
@@ -137,7 +193,7 @@ export class CounterValue {
     @select(state => state.counter) counterSelectedWithFunction;
 
     // this selects `counter` from the store and multiples it by two
-    @select(state => state.counter * 2) 
+    @select(state => state.counter * 2)
     counterSelectedWithFuntionAndMultipliedByTwo: Observable<any>;
 }
 ```
@@ -448,7 +504,7 @@ class App {
 
 ### `configureStore()`
 
-Initializes your ngRedux store. This should be called once, typically in your
+Adds your ngRedux store to NgRedux. This should be called once, typically in your
 top-level app component's constructor.
 
 __Arguments:__
@@ -467,13 +523,47 @@ Async pipe to bind its values into your template.
 
 __Arguments:__
 
-* `key` \(*string*): A key within the state that you want to subscribe to. 
-* `selector` \(*Function*): A function that accepts the application state, and returns the slice you want subscribe to for changes. 
+* `key` \(*string*): A key within the state that you want to subscribe to.
+* `selector` \(*Function*): A function that accepts the application state, and returns the slice you want subscribe to for changes.
 
 e.g:
 ```typescript
 this.counter$ = this.ngRedux.select(state=>state.counter);
-// or 
+// or
+this.counterSubscription = this.ngRedux
+  .select(state=>state.counter)
+  .subscribe(count=>this.counter = count);
+// or
+
+this.counter$ = this.ngRedux.select('counter');  
+```
+
+### `provideStore()`
+
+Initializes your ngRedux store. This should be called once, typically in your
+top-level app component's constructor. If `configureStore`
+has been used this cannot be used.
+
+__Arguments:__
+
+* `rootReducer` \(*Store*): Your app's store.
+
+### select(key | function,[comparer]) => Observable
+
+Exposes a slice of state as an observable. Accepts either a property name or a selector function.
+
+If using the async pipe, you do not need to subscribe to it explicitly, but can use the angular
+Async pipe to bind its values into your template.
+
+__Arguments:__
+
+* `key` \(*string*): A key within the state that you want to subscribe to.
+* `selector` \(*Function*): A function that accepts the application state, and returns the slice you want subscribe to for changes.
+
+e.g:
+```typescript
+this.counter$ = this.ngRedux.select(state=>state.counter);
+// or
 this.counterSubscription = this.ngRedux
   .select(state=>state.counter)
   .subscribe(count=>this.counter = count);

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ and optionally middlewares and enhancers as you would in Redux directly.
 
 ```typescript
 import { NgRedux } from 'ng2-redux';
-const reduxLogger = require('redux-logger');
+import reduxLogger from 'redux-logger';
 import { rootReducer } from './reducers';
 
 interface IAppState {
@@ -450,7 +450,7 @@ to make sure that what we pass to ngRedux has a properly-bound function context.
 
 ```typescript
 import { LogRemoteName } from './middleware/log-remote-name';
-const reduxLogger = require('redux-logger');
+import reduxLogger from 'redux-logger';
 
 @Component({
   providers: [ LogRemoteName ],
@@ -480,7 +480,7 @@ Here's how to enable them in your app (you probably only want to do
 this in development mode):
 
 ```typescript
-const enhancers = [];
+let enhancers = [];
 
 // Add Whatever other enhancers you want.
 

--- a/src/___tests___/components/ng-redux.spec.ts
+++ b/src/___tests___/components/ng-redux.spec.ts
@@ -130,11 +130,12 @@ describe('NgRedux Observable Store', () => {
     bar: string;
     baz: number;
   };
-  
+
   let connector;
   let targetObj;
   let defaultState;
   let rootReducer;
+  let store;
   let ngRedux;
   let mockAppRef;
 
@@ -157,6 +158,8 @@ describe('NgRedux Observable Store', () => {
           return state;
       }
     };
+
+    store = createStore(rootReducer);
 
     mockAppRef = {
       tick: sinon.spy()
@@ -288,5 +291,32 @@ describe('NgRedux Observable Store', () => {
       expect(mockAppRef.tick).to.have.been.calledOnce;
     });
 
-});
+  it('should throw when the store is provided after it has been configured',
+    () => {
+    // Configured once in beforeEach, now we try to provide a store when
+    // we already have configured one.
 
+    expect(ngRedux.provideStore.bind(store))
+      .to.throw(Error);
+  });
+
+  it('should set the store when a store is provided',
+    () => {
+
+    delete ngRedux._store;
+    delete ngRedux._$store;
+
+    expect(ngRedux._store).to.be.undefined;
+    expect(ngRedux._$store).to.be.undefined;
+
+    expect(ngRedux.provideStore.bind(ngRedux, store))
+      .to.not.throw(Error);
+
+    expect(ngRedux._store).to.have.all.keys(
+      'dispatch',
+      'subscribe',
+      'getState',
+      'replaceReducer'
+    );
+  });
+});

--- a/src/components/ng-redux.ts
+++ b/src/components/ng-redux.ts
@@ -50,7 +50,7 @@ export class NgRedux<RootState> {
     /**
      * configures a Redux store and allows NgRedux to observe and dispatch
      * to it.
-     * 
+     *
      * This should only be called once for the lifetime of your app, for
      * example in the constructor of your root component.
      *
@@ -74,26 +74,24 @@ export class NgRedux<RootState> {
                 )(createStore);
         const store = finalCreateStore(reducer, initState);
 
-        this._store = store;
-        this._store$ = new BehaviorSubject(store.getState());
-        this._store.subscribe(() => {
-            this._store$.next(this._store.getState());
-
-            // For devTools support.
-            if (this._applicationRef) {
-                this._applicationRef.tick();
-            }    
-        });
-
-        this._defaultMapStateToTarget = () => ({});
-        this._defaultMapDispatchToTarget = dispatch => ({ dispatch });
-        const cleanedStore = omit(store, [
-            'dispatch',
-            'getState',
-            'subscribe',
-            'replaceReducer']);
-        Object.assign(this, cleanedStore);
+        this.setStore(store);
     }
+
+    /**
+     * Accepts a Redux store, then sets it in NgRedux and
+     * allows NgRedux to observe and dispatch to it.
+     *
+     * This should only be called once for the lifetime of your app, for
+     * example in the constructor of your root component. If configureStore
+     * has been used this cannot be used.
+     *
+     * @param {Redux.Store} store Your app's store
+     */
+    provideStore(store: Store<RootState>) {
+        invariant(!this._store, 'Store already configured!');
+
+        this.setStore(store);
+    };
 
     /**
      * Get an observable from the attached Redux store.
@@ -105,7 +103,7 @@ export class NgRedux<RootState> {
     };
 
     /**
-     * Select a slice of state to expose as an observable. 
+     * Select a slice of state to expose as an observable.
      *
      * @template S
      * @param {(string | number | symbol | ((state: RootState) => S))}
@@ -156,21 +154,21 @@ export class NgRedux<RootState> {
     };
 
     /**
-     * Connect your component to your redux state. 
-     * 
+     * Connect your component to your redux state.
+     *
      * @param {*} mapStateToTarget connect will subscribe to Redux store
      * updates. Any time it updates, mapStateToTarget will be called. Its
      * result must be a plain object, and it will be merged into `target`.
      * If you have a component which simply triggers actions without needing
      * any state you can pass null to `mapStateToTarget`.
-     * 
+     *
      * @param {*} mapDispatchToTarget  Optional. If an object is passed,
      * each function inside it will be assumed to be a Redux action creator.
      * An object with the same function names, but bound to a Redux store,
      * will be merged onto `target`. If a function is passed, it will be given
      * `dispatch`. It’s up to you to return an object that somehow uses
      * `dispatch` to bind action creators in your own way. (Tip: you may
-     * use the 
+     * use the
      * [`bindActionCreators()`]
      * (http://gaearon.github.io/redux/docs/api/bindActionCreators.html)
      * helper from Redux.).
@@ -230,7 +228,7 @@ export class NgRedux<RootState> {
 
     /**
      * Subscribe to the Redux store changes
-     * 
+     *
      * @param {() => void} listener callback to invoke when the state is updated
      * @returns a function to unsubscribe
      */
@@ -252,7 +250,7 @@ export class NgRedux<RootState> {
     };
 
     /**
-     * Dispatch an action to Redux 
+     * Dispatch an action to Redux
      */
     dispatch = <A extends Action>(action: A): any => {
         return this._store.dispatch(action);
@@ -291,5 +289,32 @@ export class NgRedux<RootState> {
 
         return finalMapDispatchToTarget(this._store.dispatch);
     };
-}
 
+    /**
+     * Helper function to set the store to NgRedux and
+     * allow NgRedux to observe and dispatch to it.
+     *
+     * @param {Redux.Store} store The redux store
+     */
+    private setStore(store: Store<RootState>) {
+        this._store = store;
+        this._store$ = new BehaviorSubject(store.getState());
+        this._store.subscribe(() => {
+            this._store$.next(this._store.getState());
+
+            // For devTools support.
+            if (this._applicationRef) {
+                this._applicationRef.tick();
+            }
+        });
+
+        this._defaultMapStateToTarget = () => ({});
+        this._defaultMapDispatchToTarget = dispatch => ({ dispatch });
+        const cleanedStore = omit(store, [
+            'dispatch',
+            'getState',
+            'subscribe',
+            'replaceReducer']);
+        Object.assign(this, cleanedStore);
+    }
+}


### PR DESCRIPTION
Hey, thanks for a great library!

This pull request brings an suggestion to NgRedux and I just want to explain why I think this is a good idea. 

I come mainly from the react community side when using Redux, and there I have been using this library called `react-redux` which I also think is great. So when using that library I wrote the stores like I would do just using Redux and then pass the store down to react-redux which then solved all the rest for me. So basically this is the desired behavior I want to get from NgRedux as well. I even have some stores created in my React applications that I would like to just copy and paste to reuse in my Angular project. So this is what this pull request brings to NgRedux. A function that accepts a already created Redux store so the users can themselves create a store how they want to do it.

This new function does not break anything old, like `configureStore()`.

I also created a new function `private setStore(store: Store<RootState>) {}` which is called by `configureStore()` and `provideStore()`.

I updated the README and CHANGELOG as well.

Let me know what you think, @e-schultz @SethDavenport. Thanks!
