### PR TITLE
Fix typo in import statement. Delete .ts extension

### DIFF
--- a/docs/intro-tutorial.md
+++ b/docs/intro-tutorial.md
@@ -300,7 +300,7 @@ they are dispatched when the user clicks the buttons:
 // Imports as before.
 
 import { NgRedux } from '@angular-redux/store'; // <- New
-import { CounterActions } from './app.actions.ts'; // <- New
+import { CounterActions } from './app.actions'; // <- New
 
 @Component({
   selector: 'app-root',


### PR DESCRIPTION
Following the intro tutorial I ran into a line containing the .ts file extension in an import statement. 