### PR TITLE
feat(dispatch): Create dispatch decorator

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "prebuild": "rimraf ./lib",
     "build": "npm run build:src && npm run build:testing",
-    "build:src": "ngc -p tsconfig.json",
+    "build:src": "ngc -p tsconfig.build.json",
     "build:testing": "ngc -p tsconfig.testing.json",
     "lint": "tslint 'src/**/*.ts'",
     "prepublish": "npm run lint && npm test && npm run build",
@@ -74,7 +74,7 @@
     "ts-node": "^3.0.2",
     "tslint": "^5.1.0",
     "typedoc": "^0.6.0",
-    "typescript": "^2.1.0",
+    "typescript": "^2.3.0",
     "zone.js": "^0.8.4"
   },
   "peerDependencies": {

--- a/src/decorators/dispatch.spec.ts
+++ b/src/decorators/dispatch.spec.ts
@@ -3,112 +3,106 @@ import { NgZone } from '@angular/core';
 import { NgRedux } from '../components/ng-redux';
 import { dispatch } from './dispatch';
 
+
 class MockNgZone {
   run = fn => fn()
 }
 
-fdescribe('@dispatch', () => {
+describe('@dispatch', () => {
   let ngRedux;
   const mockNgZone = new MockNgZone() as NgZone;
-  let targetObj;
   let defaultState;
   let rootReducer;
 
   beforeEach(() => {
     defaultState = {
-      foo: 'bar',
-      baz: -1
+      value: 'init-value',
+      instanceProperty: 'init-instanceProperty'
     };
     rootReducer = (state = defaultState, action) => {
-      const newState = Object.assign({}, state, { baz: action.payload });
-      return newState;
+      switch (action.type) {
+        case 'TEST':
+          const { value, instanceProperty } = action.payload;
+          return Object.assign({}, state, { value, instanceProperty });
+        default:
+          return state;
+      }
+
     };
-    targetObj = {};
     ngRedux = new NgRedux(mockNgZone);
     ngRedux.configureStore(rootReducer, defaultState);
   });
 
   it('should call dispatch with the result of the function', () => {
-    class TestClass {
-      instanceProperty = 'test'
-      @dispatch()
-      myMethod(value) {
-        return {
-          type: 'TEST',
-          payload: {
-            value,
-            instanceProperty: this.instanceProperty
-          }
-        }
-      }
-    }
+
     spyOn(NgRedux.instance, 'dispatch');
     const instance = new TestClass();
-    const result = instance.myMethod('test payload');
-    expect(result.type).toBe('TEST');
-    expect(NgRedux.instance.dispatch).toHaveBeenCalledWith({
-      type: 'TEST', payload: {
-        value: 'test payload',
+    const result = instance.classMethod('class method');
+    const expectedArgs = {
+      type: 'TEST',
+      payload: {
+        value: 'class method',
         instanceProperty: 'test'
       }
-    })
+    }
+    expect(result.type).toBe('TEST');
+    expect(result.payload.value).toBe('class method');
+    expect(result.payload.instanceProperty).toBe('test');
+    expect(NgRedux.instance.dispatch).toHaveBeenCalledWith(expectedArgs)
   });
 
   it('should work with property initalizers', () => {
-    class TestClass {
-      instanceProperty = 'test'
-      @dispatch()
-      boundProperty = (value) => {
-        return {
-          type: 'TEST',
-          payload: {
-            value,
-            instanceProperty: this.instanceProperty
-          }
-        }
-      }
-    }
+
     spyOn(NgRedux.instance, 'dispatch');
     const instance = new TestClass();
-    const result = instance.boundProperty('test payload');
-    expect(result.type).toBe('TEST');
-    expect(NgRedux.instance.dispatch).toHaveBeenCalledWith({
-      type: 'TEST', payload: {
-        value: 'test payload',
+    const result = instance.boundProperty('bound property');
+    const expectedArgs = {
+      type: 'TEST',
+      payload: {
+        value: 'bound property',
         instanceProperty: 'test'
       }
-    })
+    }
+    expect(result.type).toBe('TEST');
+    expect(result.payload.value).toBe('bound property');
+    expect(result.payload.instanceProperty).toBe('test');
+    expect(NgRedux.instance.dispatch).toHaveBeenCalledWith(expectedArgs)
   })
 
   it('work with properties bound to function defined outside of the class', () => {
-    function test(value) {
-      return {
-        type: 'TEST',
-        payload: {
-          value,
-          instanceProperty: this.instanceProperty
-        }
-      }
-    }
-    class TestClass {
-      instanceProperty = 'test'
-      @dispatch()
-      boundProperty = test;
-    }
     spyOn(NgRedux.instance, 'dispatch');
     const instance = new TestClass();
-    const result = instance.boundProperty('test payload');
-    expect(result.type).toBe('TEST');
-    expect(NgRedux.instance.dispatch).toHaveBeenCalledWith({
-      type: 'TEST', payload: {
-        value: 'test payload',
+    const result = instance.externalFunction('external function');
+    const expectedArgs = {
+      type: 'TEST',
+      payload: {
+        value: 'external function',
         instanceProperty: 'test'
       }
-    })
+    }
+    expect(result.type).toBe('TEST');
+    expect(result.payload.value).toBe('external function');
+    expect(result.payload.instanceProperty).toBe('test');
+    expect(NgRedux.instance.dispatch).toHaveBeenCalledWith(expectedArgs);
   })
 
-  it('work with properties bound to fat arrow defined outside of the class', () => {
-    const test = (value) => {
+
+
+  function externalFunction(value) {
+    return {
+      type: 'TEST',
+      payload: {
+        value,
+        instanceProperty: this.instanceProperty
+      }
+    }
+  }
+  class TestClass {
+    instanceProperty = 'test'
+    @dispatch()
+    externalFunction = externalFunction
+    @dispatch()
+    classMethod(value) {
       return {
         type: 'TEST',
         payload: {
@@ -117,20 +111,16 @@ fdescribe('@dispatch', () => {
         }
       }
     }
-    class TestClass {
-      instanceProperty = 'test'
-      @dispatch()
-      boundProperty = test;
-    }
-    spyOn(NgRedux.instance, 'dispatch');
-    const instance = new TestClass();
-    const result = instance.boundProperty('test payload');
-    expect(result.type).toBe('TEST');
-    expect(NgRedux.instance.dispatch).toHaveBeenCalledWith({
-      type: 'TEST', payload: {
-        value: 'test payload',
-        instanceProperty: undefined
+
+    @dispatch()
+    boundProperty = (value) => {
+      return {
+        type: 'TEST',
+        payload: {
+          value,
+          instanceProperty: this.instanceProperty
+        }
       }
-    })
-  })
+    }
+  }
 });

--- a/src/decorators/dispatch.spec.ts
+++ b/src/decorators/dispatch.spec.ts
@@ -1,0 +1,136 @@
+import 'reflect-metadata';
+import { NgZone } from '@angular/core';
+import { NgRedux } from '../components/ng-redux';
+import { dispatch } from './dispatch';
+
+class MockNgZone {
+  run = fn => fn()
+}
+
+fdescribe('@dispatch', () => {
+  let ngRedux;
+  const mockNgZone = new MockNgZone() as NgZone;
+  let targetObj;
+  let defaultState;
+  let rootReducer;
+
+  beforeEach(() => {
+    defaultState = {
+      foo: 'bar',
+      baz: -1
+    };
+    rootReducer = (state = defaultState, action) => {
+      const newState = Object.assign({}, state, { baz: action.payload });
+      return newState;
+    };
+    targetObj = {};
+    ngRedux = new NgRedux(mockNgZone);
+    ngRedux.configureStore(rootReducer, defaultState);
+  });
+
+  it('should call dispatch with the result of the function', () => {
+    class TestClass {
+      instanceProperty = 'test'
+      @dispatch()
+      myMethod(value) {
+        return {
+          type: 'TEST',
+          payload: {
+            value,
+            instanceProperty: this.instanceProperty
+          }
+        }
+      }
+    }
+    spyOn(NgRedux.instance, 'dispatch');
+    const instance = new TestClass();
+    const result = instance.myMethod('test payload');
+    expect(result.type).toBe('TEST');
+    expect(NgRedux.instance.dispatch).toHaveBeenCalledWith({
+      type: 'TEST', payload: {
+        value: 'test payload',
+        instanceProperty: 'test'
+      }
+    })
+  });
+
+  it('should work with property initalizers', () => {
+    class TestClass {
+      instanceProperty = 'test'
+      @dispatch()
+      boundProperty = (value) => {
+        return {
+          type: 'TEST',
+          payload: {
+            value,
+            instanceProperty: this.instanceProperty
+          }
+        }
+      }
+    }
+    spyOn(NgRedux.instance, 'dispatch');
+    const instance = new TestClass();
+    const result = instance.boundProperty('test payload');
+    expect(result.type).toBe('TEST');
+    expect(NgRedux.instance.dispatch).toHaveBeenCalledWith({
+      type: 'TEST', payload: {
+        value: 'test payload',
+        instanceProperty: 'test'
+      }
+    })
+  })
+
+  it('work with properties bound to function defined outside of the class', () => {
+    function test(value) {
+      return {
+        type: 'TEST',
+        payload: {
+          value,
+          instanceProperty: this.instanceProperty
+        }
+      }
+    }
+    class TestClass {
+      instanceProperty = 'test'
+      @dispatch()
+      boundProperty = test;
+    }
+    spyOn(NgRedux.instance, 'dispatch');
+    const instance = new TestClass();
+    const result = instance.boundProperty('test payload');
+    expect(result.type).toBe('TEST');
+    expect(NgRedux.instance.dispatch).toHaveBeenCalledWith({
+      type: 'TEST', payload: {
+        value: 'test payload',
+        instanceProperty: 'test'
+      }
+    })
+  })
+
+  it('work with properties bound to fat arrow defined outside of the class', () => {
+    const test = (value) => {
+      return {
+        type: 'TEST',
+        payload: {
+          value,
+          instanceProperty: this.instanceProperty
+        }
+      }
+    }
+    class TestClass {
+      instanceProperty = 'test'
+      @dispatch()
+      boundProperty = test;
+    }
+    spyOn(NgRedux.instance, 'dispatch');
+    const instance = new TestClass();
+    const result = instance.boundProperty('test payload');
+    expect(result.type).toBe('TEST');
+    expect(NgRedux.instance.dispatch).toHaveBeenCalledWith({
+      type: 'TEST', payload: {
+        value: 'test payload',
+        instanceProperty: undefined
+      }
+    })
+  })
+});

--- a/src/decorators/dispatch.ts
+++ b/src/decorators/dispatch.ts
@@ -2,24 +2,25 @@ import {
   NgRedux,
 } from '../components/ng-redux';
 
-
-export function dispatch(options?: any) {
-  return function dispatch(target, key, descriptor?) {
-
+export function dispatch(): void | any {
+  return function dispatchDecorator(target: object, key: string | symbol | number, descriptor?: PropertyDescriptor) {
     let originalMethod: Function;
+
+    descriptor = descriptor || Object.getOwnPropertyDescriptor(target, key);
     const wrapped = function (...args) {
+
       const result = originalMethod.apply(this, args);
       NgRedux.instance.dispatch(result);
       return result;
     }
+
     if (descriptor === undefined) {
       const dispatchDescriptor: PropertyDescriptor = {
         get: () => wrapped,
         set: (setMethod) => originalMethod = setMethod,
       }
       Object.defineProperty(target, key, dispatchDescriptor)
-
-      // return descriptor;
+      return;
     } else {
       originalMethod = descriptor.value;
       descriptor.value = wrapped;

--- a/src/decorators/dispatch.ts
+++ b/src/decorators/dispatch.ts
@@ -1,0 +1,30 @@
+import {
+  NgRedux,
+} from '../components/ng-redux';
+
+
+export function dispatch(options?: any) {
+  return function dispatch(target, key, descriptor?) {
+
+    let originalMethod: Function;
+    const wrapped = function (...args) {
+      const result = originalMethod.apply(this, args);
+      NgRedux.instance.dispatch(result);
+      return result;
+    }
+    if (descriptor === undefined) {
+      const dispatchDescriptor: PropertyDescriptor = {
+        get: () => wrapped,
+        set: (setMethod) => originalMethod = setMethod,
+      }
+      Object.defineProperty(target, key, dispatchDescriptor)
+
+      // return descriptor;
+    } else {
+      originalMethod = descriptor.value;
+      descriptor.value = wrapped;
+      return descriptor;
+    }
+
+  }
+}

--- a/src/decorators/select.spec.ts
+++ b/src/decorators/select.spec.ts
@@ -1,6 +1,5 @@
 import 'reflect-metadata';
 import { NgZone } from '@angular/core';
-
 import { NgRedux } from '../components/ng-redux';
 import { select } from './select';
 
@@ -31,51 +30,51 @@ describe('@select', () => {
 
   describe('when passed no arguments', () => {
     it('automatically attempts to bind to a store property that matches the' +
-       ' name of the class property', () => {
-      class MockClass {
-        @select() baz: any;
-      }
+      ' name of the class property', () => {
+        class MockClass {
+          @select() baz: any;
+        }
 
-      const mockInstance = new MockClass();
-      let value;
-      const expectedValue = 1;
+        const mockInstance = new MockClass();
+        let value;
+        const expectedValue = 1;
 
-      mockInstance.baz.subscribe((val) => value = val);
-      ngRedux.dispatch({type: 'nvm', payload: expectedValue});
-      expect(value).toEqual(expectedValue);
-    });
+        mockInstance.baz.subscribe((val) => value = val);
+        ngRedux.dispatch({ type: 'nvm', payload: expectedValue });
+        expect(value).toEqual(expectedValue);
+      });
 
     it('attempts to bind by name ignoring any $ characters in the class ' +
-       'property name', () => {
-      class MockClass {
-        @select() baz$: any;
-      }
+      'property name', () => {
+        class MockClass {
+          @select() baz$: any;
+        }
 
-      const mockInstance = new MockClass();
-      let value;
-      const expectedValue = 2;
+        const mockInstance = new MockClass();
+        let value;
+        const expectedValue = 2;
 
-      mockInstance.baz$.subscribe(val => value = val);
-      ngRedux.dispatch({type: 'nvm', payload: expectedValue});
-      expect(value).toEqual(expectedValue);
-    });
+        mockInstance.baz$.subscribe(val => value = val);
+        ngRedux.dispatch({ type: 'nvm', payload: expectedValue });
+        expect(value).toEqual(expectedValue);
+      });
   });
 
   describe('when passed a string', () => {
     it('attempts to bind to the store property whose name matches the ' +
-       'string value', () => {
-      class MockClass {
-        @select('baz') asdf: any;
-      }
+      'string value', () => {
+        class MockClass {
+          @select('baz') asdf: any;
+        }
 
-      const mockInstance = new MockClass();
-      let value;
-      const expectedValue = 3;
+        const mockInstance = new MockClass();
+        let value;
+        const expectedValue = 3;
 
-      mockInstance.asdf.subscribe(val => value = val);
-      ngRedux.dispatch({type: 'nvm', payload: expectedValue});
-      expect(value).toEqual(expectedValue);
-    });
+        mockInstance.asdf.subscribe(val => value = val);
+        ngRedux.dispatch({ type: 'nvm', payload: expectedValue });
+        expect(value).toEqual(expectedValue);
+      });
   });
 
   describe('when passed a function', () => {
@@ -90,7 +89,7 @@ describe('@select', () => {
       const expectedValue = 10;
 
       mockInstance.asdf.subscribe(val => value = val);
-      ngRedux.dispatch({type: 'nvm', payload: expectedValue / 2});
+      ngRedux.dispatch({ type: 'nvm', payload: expectedValue / 2 });
       expect(value).toEqual(expectedValue);
     });
   });
@@ -108,7 +107,7 @@ describe('@select', () => {
 
       const mockInstance = new MockClass();
       mockInstance.asdf.subscribe(val => expect(val).not.toEqual(1));
-      ngRedux.dispatch({type: 'nvm', payload: 1});
+      ngRedux.dispatch({ type: 'nvm', payload: 1 });
     });
 
     it('should trigger next when comparer returns false', () => {
@@ -120,7 +119,7 @@ describe('@select', () => {
       let value;
 
       mockInstance.asdf.subscribe(val => value = val);
-      ngRedux.dispatch({type: 'nvm', payload: 2});
+      ngRedux.dispatch({ type: 'nvm', payload: 2 });
       expect(value).toEqual(2);
     });
 
@@ -134,8 +133,8 @@ describe('@select', () => {
       const mockInstance = new MockClass();
       mockInstance.asdf.subscribe(val => null);
 
-      ngRedux.dispatch({type: 'nvm', payload: 1});
-      ngRedux.dispatch({type: 'nvm', payload: 2});
+      ngRedux.dispatch({ type: 'nvm', payload: 1 });
+      ngRedux.dispatch({ type: 'nvm', payload: 2 });
 
       expect(spy).toHaveBeenCalledWith(undefined, 1);
       expect(spy).toHaveBeenCalledWith(1, 2);

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import {
 } from './components/ng-redux';
 import { DevToolsExtension } from './components/dev-tools';
 import { select } from './decorators/select';
+import { dispatch } from './decorators/dispatch';
 import { NgReduxModule } from './ng-redux.module';
 
 // Warning: don't do this:
@@ -24,4 +25,5 @@ export {
   NgReduxModule,
   DevToolsExtension,
   select,
+  dispatch
 };

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -29,7 +29,8 @@
   ],
   "exclude": [
     "node_modules",
-    "lib"
+    "lib",
+    "**/*.spec.ts"
   ],
   "angularCompilerOptions": {
     "strictMetadataEmit": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1292,9 +1292,9 @@ typescript@2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.2.2.tgz#606022508479b55ffa368b58fee963a03dfd7b0c"
 
-typescript@^2.1.0:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.2.1.tgz#4862b662b988a4c8ff691cc7969622d24db76ae9"
+typescript@^2.3.0:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.3.2.tgz#f0f045e196f69a72f06b25fd3bd39d01c3ce9984"
 
 uglify-js@^2.6:
   version "2.8.22"


### PR DESCRIPTION
Initial implementation of a `@dispatch` decorator.

```ts
class TestClass {
      instanceProperty = 'test'
      @dispatch()
      myMethod(value) {
        return {
          type: 'TEST',
          payload: {
            value,
            instanceProperty: this.instanceProperty
          }
        }
      }
    }

```

Need to do some integration testing, and ensure that the context of `this` is preserved as expected if action creators are using it.

Feature was requested in #384 - needs some more testing, code cleanup, better typings, etc. 