### PR TITLE
[Fixes #269] Adds `@select$` decorator

### DIFF
--- a/src/components/ng-redux.ts
+++ b/src/components/ng-redux.ts
@@ -79,7 +79,6 @@ export class NgRedux<RootState> {
         ...enhancers
     )(createStore);
     const store = finalCreateStore(reducer, initState);
-
     this.setStore(store);
   }
 

--- a/src/decorators/select.ts
+++ b/src/decorators/select.ts
@@ -1,11 +1,5 @@
-import {
-  Selector,
-  Comparator,
-  NgRedux,
-} from '../components/ng-redux';
-
-/** @hidden */
-export type PropertyDecorator = (target: any, propertyKey: string) => void;
+import { Selector, Comparator, NgRedux } from '../components/ng-redux';
+import { Observable } from 'rxjs/Observable';
 
 /**
  * Selects an observable from the store, and attaches it to the decorated
@@ -20,7 +14,7 @@ export type PropertyDecorator = (target: any, propertyKey: string) => void;
  */
 export function select<T>(
   selector?: Selector<any, T>,
-  comparator?: Comparator): PropertyDecorator {
+  comparator?: Comparator) {
 
   return function decorate(target: any, key: string): void {
     let bindingKey = selector;
@@ -32,6 +26,38 @@ export function select<T>(
 
     function getter() {
       return NgRedux.instance.select(bindingKey, comparator);
+    }
+
+    // Replace decorated property with a getter that returns the observable.
+    if (delete target[key]) {
+      Object.defineProperty(target, key, {
+        get: getter,
+        enumerable: true,
+        configurable: true
+      });
+    }
+  };
+}
+
+export type Transformer<RootState, V> = (store$: Observable<RootState>) => Observable<V>
+
+/**
+ * Selects an obsersable of the entire store, and runs it through the given transformer
+ * function. A transformer function takes the store observable as an input and returns
+ * a derived observable from it. That derived observable is run through distinctUntilChanges
+ * with the given optional comparator and attached to the store property.
+ * 
+ * Think of a Transformer as a FunctionSelector that operates on observables instead of
+ * values.
+ */
+export function select$<T>(
+  transformer: Transformer<any, T>,
+  comparator?: Comparator) {
+
+  return function decorate(target: any, key: string): void {
+    function getter() {
+      return transformer(NgRedux.instance.select())
+          .distinctUntilChanged(comparator);
     }
 
     // Replace decorated property with a getter that returns the observable.

--- a/src/decorators/select.ts
+++ b/src/decorators/select.ts
@@ -42,7 +42,7 @@ export function select<T>(
 export type Transformer<RootState, V> = (store$: Observable<RootState>) => Observable<V>
 
 /**
- * Selects an obsersable of the entire store, and runs it through the given transformer
+ * Selects an observable of the entire store, and runs it through the given transformer
  * function. A transformer function takes the store observable as an input and returns
  * a derived observable from it. That derived observable is run through distinctUntilChanges
  * with the given optional comparator and attached to the store property.

--- a/src/decorators/select.ts
+++ b/src/decorators/select.ts
@@ -46,7 +46,7 @@ export type Transformer<RootState, V> = (store$: Observable<RootState>) => Obser
  * function. A transformer function takes the store observable as an input and returns
  * a derived observable from it. That derived observable is run through distinctUntilChanges
  * with the given optional comparator and attached to the store property.
- * 
+ *
  * Think of a Transformer as a FunctionSelector that operates on observables instead of
  * values.
  */

--- a/src/decorators/select.ts
+++ b/src/decorators/select.ts
@@ -1,5 +1,6 @@
 import { Selector, Comparator, NgRedux } from '../components/ng-redux';
 import { Observable } from 'rxjs/Observable';
+import 'rxjs/add/operator/let'
 
 /**
  * Selects an observable from the store, and attaches it to the decorated
@@ -56,7 +57,8 @@ export function select$<T>(
 
   return function decorate(target: any, key: string): void {
     function getter() {
-      return transformer(NgRedux.instance.select())
+      return NgRedux.instance.select()
+          .let(transformer)
           .distinctUntilChanged(comparator);
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ import {
   Comparator,
 } from './components/ng-redux';
 import { DevToolsExtension } from './components/dev-tools';
-import { select } from './decorators/select';
+import { select, select$ } from './decorators/select';
 import { NgReduxModule } from './ng-redux.module';
 
 // Warning: don't do this:
@@ -24,4 +24,5 @@ export {
   NgReduxModule,
   DevToolsExtension,
   select,
+  select$,
 };


### PR DESCRIPTION
`@select$` is a version of `@select` that lets you attach a chain of RXJS operations directly in your decorator. So instead of doing

```typescript
class Foo {
  readonly debouncedFooBar$: Observable<string>;

  constructor(ngRedux: NgRedux) {
    this.debouncedFooBar$ = ngRedux.select('foo')
      .map(foo => foo.bar)
      .debounce(300);
  }
}
```

or

```typescript
class Foo {
  readonly @select() foo$: Observable<IFoo>;
  readonly debouncedFooBar$: Observable<string>

  constructor() {
    this.debouncedFooBar$ = this.foo$
      .map(foo => foo.bar)
      .debounce(300);
  }
}
```

You can instead do

```typescript
export const getBarAndDebounce = obs$ => obs$
  .map(foo => foo.bar)
  .debounce(300);

class Foo {
  readonly debouncedFooBar$: Observable<string> = @select$(getBarAndDebounce);
}
```