### PR TITLE
Fix typings for dispatch method

### DIFF
--- a/src/components/ng-redux.ts
+++ b/src/components/ng-redux.ts
@@ -8,7 +8,8 @@ import {
   Unsubscribe,
   createStore,
   applyMiddleware,
-  compose
+  compose,
+  Dispatch,
 } from 'redux';
 
 import { NgZone } from '@angular/core';
@@ -166,7 +167,7 @@ export class NgRedux<RootState> {
   /**
    * Dispatch an action to Redux
    */
-  dispatch = <A extends Action>(action: A): any => {
+  dispatch: Dispatch<RootState> = action => {
     if (!this._store) {
       throw new Error('Dispatch failed: did you forget to configure your store? ' +
         'https://github.com/angular-redux/@angular-redux/core/blob/master/' +


### PR DESCRIPTION
This is important for middlewares like redux-thunk that allow you to dispatch other things than Actions.

[Fixes #264] [Fixes #386] [Fixes #211]