### PR TITLE
Added selector parameter to @select$ after all

### DIFF
--- a/src/decorators/select.spec.ts
+++ b/src/decorators/select.spec.ts
@@ -124,13 +124,10 @@ describe('Select decorators', () => {
   });
 
   describe('@select$', () => {
-    it('applies a transformer to the observable', done => {
-      class MockClass {
-        @select$(state$ => state$
-          .map(state => state.baz)
-          .map(baz => baz * 2)) baz$: Observable<number>;
-      }
+    const transformer = baz$ => baz$.map(baz => 2 * baz);
 
+    it('applies a transformer to the observable', done => {
+      class MockClass { @select$('baz', transformer) baz$: Observable<number>; }
       const mockInstance = new MockClass();
 
       mockInstance.baz$
@@ -145,8 +142,7 @@ describe('Select decorators', () => {
 
     describe('when passed a comparator', () => {
       const comparator = (x: any, y: any): boolean => y === 1;
-      const transformer = state$ => state$.map(state => state.baz);
-      class MockClass { @select$(transformer, comparator) baz$: Observable<number> }
+      class MockClass { @select$('baz', transformer, comparator) baz$: Observable<number> }
 
       it('should only trigger next when the comparator returns true', done => {
         const mockInstance = new MockClass();
@@ -154,7 +150,7 @@ describe('Select decorators', () => {
           .take(2)
           .toArray()
           .subscribe(
-            values => expect(values).toEqual([-1, 2]),
+            values => expect(values).toEqual([-2, 2]),
             null,
             done);
         ngRedux.dispatch({type: 'nvm', payload: 1});
@@ -163,7 +159,7 @@ describe('Select decorators', () => {
 
       it('should receive previous and next value for comparison', done => {
         const spy = jasmine.createSpy('spy');
-        class SpyClass { @select$(transformer, spy) baz$: Observable<number> };
+        class SpyClass { @select$('baz', transformer, spy) baz$: Observable<number> };
 
         const mockInstance = new SpyClass();
         mockInstance.baz$
@@ -173,8 +169,8 @@ describe('Select decorators', () => {
         ngRedux.dispatch({type: 'nvm', payload: 1});
         ngRedux.dispatch({type: 'nvm', payload: 2});
 
-        expect(spy).toHaveBeenCalledWith(-1, 1);
-        expect(spy).toHaveBeenCalledWith(1, 2);
+        expect(spy).toHaveBeenCalledWith(-2, 2);
+        expect(spy).toHaveBeenCalledWith(2, 4);
       });
     });
   });

--- a/src/decorators/select.ts
+++ b/src/decorators/select.ts
@@ -43,23 +43,24 @@ export function select<T>(
 export type Transformer<RootState, V> = (store$: Observable<RootState>) => Observable<V>
 
 /**
- * Selects an observable of the entire store, and runs it through the given transformer
- * function. A transformer function takes the store observable as an input and returns
- * a derived observable from it. That derived observable is run through distinctUntilChanges
- * with the given optional comparator and attached to the store property.
+ * Selects an observable using the given path selector, and runs it through the given
+ * transformer function. A transformer function takes the store observable as an input and
+ * returns a derived observable from it. That derived observable is run through
+ * distinctUntilChanges with the given optional comparator and attached to the store property.
  *
  * Think of a Transformer as a FunctionSelector that operates on observables instead of
  * values.
  */
 export function select$<T>(
+  selector: Selector<any, T>,
   transformer: Transformer<any, T>,
   comparator?: Comparator) {
 
   return function decorate(target: any, key: string): void {
     function getter() {
-      return NgRedux.instance.select()
-          .let(transformer)
-          .distinctUntilChanged(comparator);
+      return NgRedux.instance.select(selector)
+        .let(transformer)
+        .distinctUntilChanged(comparator);
     }
 
     // Replace decorated property with a getter that returns the observable.


### PR DESCRIPTION
Because this: `@select$(veryComplexTransformer)` would be inefficient because the disctinctUntilChanged happens after `veryComplexTransformer` runs, on every store update.

Being able to use `@select$(['path', 'to', 'something'], veryComplexTransformer)`  will only run `veryComplexTransformer` when `store.path.to.someting` changes, which is better.