### PR TITLE
Remove unused testing module import

### DIFF
--- a/testing/ng-redux-testing.module.ts
+++ b/testing/ng-redux-testing.module.ts
@@ -1,4 +1,4 @@
-import { NgModule, ClassProvider } from '@angular/core';
+import { NgModule } from '@angular/core';
 import { NgRedux, DevToolsExtension } from '@angular-redux/store';
 import { MockNgRedux } from './ng-redux.mock';
 import { MockDevToolsExtension } from './dev-tools.mock';


### PR DESCRIPTION
The unused `ClassProvider` import in the testing module is throwing errors when the `noUnusedLocals` option is turned on in `tsconfig.json`.