### PR TITLE
[Fixes #372] Add support for redux-batch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@angular-redux/store",
-  "version": "6.2.1",
+  "version": "6.3.0-alpha.0",
   "description": "Angular 2 bindings for Redux",
   "main": "./lib/src/index.js",
   "scripts": {

--- a/src/components/ng-redux.ts
+++ b/src/components/ng-redux.ts
@@ -17,7 +17,6 @@ import { Observable } from 'rxjs/Observable';
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/filter';
-import 'rxjs/add/observable/from';
 import 'rxjs/add/operator/distinctUntilChanged';
 import 'rxjs/add/operator/switchMap';
 
@@ -47,9 +46,9 @@ export class NgRedux<RootState> {
   constructor(
     private ngZone: NgZone) {
     NgRedux.instance = this;
-    this._store$ = new BehaviorSubject<RootState>(null)
-      .filter(n => n !== null)
-      .switchMap(n => Observable.from(n as any)) as BehaviorSubject<RootState>;
+    this._store$ = new BehaviorSubject<RootState>(undefined)
+      .filter(n => n !== undefined)
+      .switchMap(n => this.storeToObservable(n as any)) as BehaviorSubject<RootState>;
   }
 
   /**
@@ -183,4 +182,10 @@ export class NgRedux<RootState> {
     this._store = store;
     this._store$.next(store as any);
   }
+
+  private storeToObservable = (store: Store<RootState>): Observable<RootState> =>
+    new Observable<RootState>(observer => {
+      observer.next(store.getState());
+      store.subscribe(() => observer.next(store.getState()));
+    });
 };


### PR DESCRIPTION
Redux-batch (`@manaflair/redux-batch`) works by overriding Redux's subscribe and notify mechanism. However, the way we were creating an observable out of the store was pushing updates independently of `store.subscribe()`. This has the effect that `observable.next()` was being called independently of redux-batch's patched subscribe/notify mechanism and selectors fire on each change of the batched action set.

The fix is to re-create our observable in terms of store.subscribe() in order to catch any adjustments made by 3rd-party enhancers.