### PR TITLE
WIP feat: lazy loaded reducers

### DIFF
--- a/src/components/ng-redux.ts
+++ b/src/components/ng-redux.ts
@@ -4,7 +4,8 @@ import {
   Unsubscribe,
   Middleware,
   Store,
-  StoreEnhancer
+  StoreEnhancer,
+  ReducersMapObject,
 } from 'redux';
 import { Observable } from 'rxjs/Observable';
 import { ObservableStore } from './observable-store';
@@ -26,13 +27,16 @@ export abstract class NgRedux<RootState> implements ObservableStore<RootState> {
    * This should only be called once for the lifetime of your app, for
    * example in the constructor of your root component.
    *
+   * In order for reducers for portions of the root state to be asynchronously
+   * loaded, rootReducer must be provided as a reducers map object.
+   *
    * @param rootReducer Your app's root reducer
    * @param initState Your app's initial state
    * @param middleware Optional Redux middlewares
    * @param enhancers Optional Redux store enhancers
    */
   abstract configureStore: (
-    rootReducer: Reducer<RootState>,
+    rootReducer: Reducer<RootState> | ReducersMapObject,
     initState: RootState,
     middleware?: Middleware[],
     enhancers?: StoreEnhancer<RootState>[]) => void
@@ -47,7 +51,18 @@ export abstract class NgRedux<RootState> implements ObservableStore<RootState> {
    *
    * @param store Your app's store
    */
-  abstract provideStore: (store: Store<RootState>) => void
+  abstract provideStore: (store: Store<RootState>) => void;
+
+  /**
+   * Extends the current root reducer with the supplied reducers map object.
+   *
+   * This allows you to asynchronously add reducers to your store to controls
+   * portions of your root state. In order to utilize this functionality, the
+   * initial reducers must be provided as a reducers map object to configureStore().
+   *
+   * @param reducers The reducers map object that contains your new reducers
+   */
+  abstract addReducers: (reducers: ReducersMapObject) => void;
 
   // Redux Store methods
   abstract dispatch: Dispatch<RootState>;

--- a/testing/ng-redux.mock.ts
+++ b/testing/ng-redux.mock.ts
@@ -5,7 +5,7 @@ import {
   ObservableStore,
   PathSelector,
 } from '@angular-redux/store';
-import { Reducer, Action, Dispatch, Middleware, Store, StoreEnhancer } from 'redux';
+import { Reducer, Action, Dispatch, Middleware, Store, StoreEnhancer, ReducersMapObject } from 'redux';
 import { Observable } from 'rxjs/Observable';
 import { Subject } from 'rxjs/Subject';
 import { ReplaySubject } from 'rxjs/ReplaySubject';
@@ -77,6 +77,7 @@ export class MockNgRedux extends NgRedux<any> {
     initState: any,
     middleware?: Middleware[],
     enhancers?: StoreEnhancer<any>[]): void => {};
+  addReducers = (reducers: ReducersMapObject) => {};
 
   configureSubStore = this.mockRootStore.configureSubStore;
   select = this.mockRootStore.select;


### PR DESCRIPTION
This is the beginning thoughts for how to address the ability to be able to load reducers into your state piecemeal if you are using a nested NgModule application structure and also to be able to lazy load parts of your state if you so wish. 

I chose the `forRoot` / `forChild` paradigm to start considering other work in the Angular ecosystem like `@angular/router`. This could also be done simply with `NgRedux.configureStore` and the new `NgRedux.addReducers` if that's more desirable for the public API.

Still TODO:
- [ ] Verify provider functionality with `angular-redux/example-app`
- [ ] Determine whether changes need to be made to the mock/testing utilities
- [ ] Add an article describing how to accomplish lazy loading to the docs