### PR TITLE
Reset `MockNgRedux.mockInstance` as part of `MockNgRedux.reset`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 6.4.3
+
+* Reset `MockNgRedux.mockInstance` as part of `MockNgRedux.reset()`.
+
 # 6.4.2
 
 * Fixed some issues with MockNgRedux and the select dectorators. See https://github.com/angular-redux/store/issues/413 for details.
@@ -73,6 +77,10 @@ export class AnimalActions {
   // ...
 }
 ```
+
+# 6.2.2
+
+* Reset `MockNgRedux.mockInstance` as part of `MockNgRedux.reset()`.
 
 # 6.2.1
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@angular-redux/store",
-  "version": "6.4.2",
+  "version": "6.4.3-alpha.0",
   "description": "Angular 2 bindings for Redux",
   "main": "./lib/src/index.js",
   "scripts": {

--- a/testing/ng-redux.mock.ts
+++ b/testing/ng-redux.mock.ts
@@ -55,6 +55,7 @@ export class MockNgRedux<RootState> extends MockObservableStore<RootState> {
   static reset(): void {
     MockNgRedux.mockInstance.reset();
     selectionMap.reset();
+    NgRedux.instance = MockNgRedux.mockInstance;
   }
 
   /** @hidden */


### PR DESCRIPTION
6.4.3 release prep.