### PR TITLE
[Fix #415] Use compiled files when importing the testing module

### DIFF
--- a/testing/package.json
+++ b/testing/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@angular-redux/store/testing",
+  "typings": "../lib/testing/index.d.ts",
+  "main": "../lib/testing/index.js"
+}


### PR DESCRIPTION
Added a package.json file in the testing directory so that imports to `@angular-redux/store/testing` resolve to the compiled files under `lib/testing` instead of the source ones.

This allows TypeScript users to compile tests while referencing the proper `.d.ts` file, which avoids issues when an app uses different compiler flags than this library.

Should also allow JS users using a transpiler like babel to use the `testing` module.