### PR TITLE
Testing module fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@angular-redux/store",
-  "version": "6.4.4",
+  "version": "6.4.5-alpha.0",
   "description": "Angular 2 bindings for Redux",
   "main": "./lib/src/index.js",
   "scripts": {

--- a/src/components/root-store.spec.ts
+++ b/src/components/root-store.spec.ts
@@ -5,6 +5,7 @@ import 'rxjs/add/operator/filter';
 import 'rxjs/add/operator/combineLatest';
 
 import { NgRedux } from './ng-redux';
+import { RootStore } from './root-store';
 import { select } from '../decorators/select';
 
 const returnPojo = () => ({});
@@ -47,7 +48,7 @@ describe('NgRedux Observable Store', () => {
     };
 
     store = createStore(rootReducer);
-    ngRedux = new NgRedux<IAppState>(mockNgZone);
+    ngRedux = new RootStore<IAppState>(mockNgZone);
     ngRedux.configureStore(rootReducer, defaultState);
   });
 
@@ -219,7 +220,7 @@ describe('NgRedux Observable Store', () => {
         _ngRedux.select(n => n.baz).subscribe(baz => this.baz = baz);
       }
     }
-    ngRedux = new NgRedux<IAppState>(mockNgZone);
+    ngRedux = new RootStore<IAppState>(mockNgZone);
 
     const someService = new SomeService(ngRedux);
     ngRedux.configureStore(rootReducer, defaultState);
@@ -235,7 +236,7 @@ describe('NgRedux Observable Store', () => {
       @select() baz$: any;
     }
 
-    ngRedux = new NgRedux<IAppState>(mockNgZone);
+    ngRedux = new RootStore<IAppState>(mockNgZone);
 
     const someService = new SomeService();
     someService
@@ -283,7 +284,7 @@ describe('Chained actions in subscriptions', () => {
       }
     };
 
-    ngRedux = new NgRedux<IAppState>(mockNgZone);
+    ngRedux = new RootStore<IAppState>(mockNgZone);
     ngRedux.configureStore(rootReducer, defaultState);
   });
 

--- a/src/components/root-store.ts
+++ b/src/components/root-store.ts
@@ -1,0 +1,102 @@
+import {
+  Store,
+  Action,
+  Reducer,
+  Middleware,
+  StoreEnhancer,
+  Unsubscribe,
+  createStore,
+  applyMiddleware,
+  compose,
+  Dispatch,
+} from 'redux';
+
+import { NgZone } from '@angular/core';
+import { Observable } from 'rxjs/Observable';
+import { BehaviorSubject } from 'rxjs/BehaviorSubject';
+import 'rxjs/add/operator/map';
+import 'rxjs/add/operator/filter';
+import 'rxjs/add/operator/distinctUntilChanged';
+import 'rxjs/add/operator/switchMap';
+import { NgRedux } from './ng-redux';
+import { Selector, PathSelector, Comparator, resolveToFunctionSelector } from './selectors';
+import { assert } from '../utils/assert';
+import { SubStore } from './sub-store';
+import { enableFractalReducers } from './fractal-reducer-map';
+import { ObservableStore } from './observable-store';
+
+export class RootStore<RootState> extends NgRedux<RootState> {
+  private _store: Store<RootState>;
+  private _store$: BehaviorSubject<RootState>;
+
+  /** @hidden */
+  constructor(private ngZone: NgZone) {
+    super();
+    NgRedux.instance = this;
+    this._store$ = new BehaviorSubject<RootState | undefined>(undefined)
+      .filter(n => n !== undefined)
+      .switchMap(n => this.storeToObservable(n as any)) as BehaviorSubject<RootState>;
+  }
+
+  configureStore = (
+    rootReducer: Reducer<RootState>,
+    initState: RootState,
+    middleware: Middleware[] = [],
+    enhancers: StoreEnhancer<RootState>[] = []): void => {
+    assert(!this._store, 'Store already configured!');
+
+    // Variable-arity compose in typescript FTW.
+    this.setStore(
+      compose.apply(null,
+        [ applyMiddleware(...middleware), ...enhancers ])(createStore)
+        (enableFractalReducers(rootReducer), initState));
+  }
+
+  provideStore = (store: Store<RootState>) => {
+    assert(!this._store, 'Store already configured!');
+    this.setStore(store);
+  };
+
+  getState = (): RootState => this._store.getState();
+
+  subscribe = (listener: () => void): Unsubscribe =>
+    this._store.subscribe(listener);
+
+  replaceReducer = (nextReducer: Reducer<RootState>): void => {
+    this._store.replaceReducer(nextReducer)
+  }
+
+  dispatch: Dispatch<RootState> = action => {
+    assert(
+      !!this._store,
+      'Dispatch failed: did you forget to configure your store? ' +
+        'https://github.com/angular-redux/@angular-redux/core/blob/master/' +
+        'README.md#quick-start');
+
+    return this.ngZone.run(() => this._store.dispatch(action));
+  };
+
+  select = <S>(
+    selector?: Selector<RootState, S>,
+    comparator?: Comparator): Observable<S> =>
+      this._store$
+        .distinctUntilChanged()
+        .map(resolveToFunctionSelector(selector))
+        .distinctUntilChanged(comparator);
+
+  configureSubStore = <SubState>(
+    basePath: PathSelector,
+    localReducer: Reducer<SubState>): ObservableStore<SubState> =>
+      new SubStore<SubState>(this, basePath, localReducer);
+
+  private setStore(store: Store<RootState>) {
+    this._store = store;
+    this._store$.next(store as any);
+  }
+
+  private storeToObservable = (store: Store<RootState>): Observable<RootState> =>
+    new Observable<RootState>(observer => {
+      observer.next(store.getState());
+      store.subscribe(() => observer.next(store.getState()));
+    });
+};

--- a/src/components/sub-store.spec.ts
+++ b/src/components/sub-store.spec.ts
@@ -1,12 +1,12 @@
 import { NgZone } from '@angular/core';
 import { async } from '@angular/core/testing'
-import { NgRedux } from './ng-redux';
+import { RootStore } from './root-store';
 
 class MockNgZone { run = fn => fn() }
 
 describe('Substore', () => {
   const defaultReducer = (state, action) => state;
-  const ngRedux = new NgRedux(new MockNgZone() as NgZone);
+  const ngRedux = new RootStore(new MockNgZone() as NgZone);
   ngRedux.configureStore(defaultReducer, {
     foo: {
       bar: { wat: { quux: 3 } },

--- a/src/decorators/dispatch.spec.ts
+++ b/src/decorators/dispatch.spec.ts
@@ -1,8 +1,8 @@
 import 'reflect-metadata';
 import { NgZone } from '@angular/core';
 import { NgRedux } from '../components/ng-redux';
+import { RootStore } from '../components/root-store';
 import { dispatch } from './dispatch';
-
 
 class MockNgZone {
   run = fn => fn()
@@ -29,7 +29,7 @@ describe('@dispatch', () => {
       }
 
     };
-    ngRedux = new NgRedux(mockNgZone);
+    ngRedux = new RootStore(mockNgZone);
     ngRedux.configureStore(rootReducer, defaultState);
   });
 

--- a/src/decorators/select.spec.ts
+++ b/src/decorators/select.spec.ts
@@ -5,7 +5,7 @@ import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/operator/toArray';
 import 'rxjs/add/operator/take';
 
-import { NgRedux } from '../components/ng-redux';
+import { RootStore } from '../components/root-store';
 import { select, select$ } from './select';
 import { selectionMap } from '../utils/selection-map';
 
@@ -26,7 +26,7 @@ describe('Select decorators', () => {
   beforeEach(() => {
     targetObj = {};
     selectionMap.reset();
-    ngRedux = new NgRedux(mockNgZone);
+    ngRedux = new RootStore(mockNgZone);
     ngRedux.configureStore(rootReducer, defaultState);
   });
 

--- a/src/ng-redux.module.ts
+++ b/src/ng-redux.module.ts
@@ -1,10 +1,11 @@
 import { NgModule, NgZone } from '@angular/core';
 import { NgRedux } from './components/ng-redux';
+import { RootStore } from './components/root-store';
 import { DevToolsExtension } from './components/dev-tools';
 
 /** @hidden */
 export function _ngReduxFactory(ngZone: NgZone) {
-  return new NgRedux(ngZone);
+  return new RootStore(ngZone);
 }
 
 @NgModule({

--- a/testing/ng-redux-testing.module.ts
+++ b/testing/ng-redux-testing.module.ts
@@ -4,7 +4,7 @@ import { MockNgRedux } from './ng-redux.mock';
 import { MockDevToolsExtension } from './dev-tools.mock';
 
 // Needs to be initialized early so @select's use the mocked version too.
-const mockNgRedux = new MockNgRedux();
+const mockNgRedux = MockNgRedux.getInstance();
 
 /** @hidden */
 export function _mockNgReduxFactory() {

--- a/testing/observable-store.mock.ts
+++ b/testing/observable-store.mock.ts
@@ -29,7 +29,7 @@ export interface SubStoreStubMap {
 }
 
 /** @hidden */
-export class MockObservableStore<State> implements ObservableStore<null> {
+export class MockObservableStore<State> implements ObservableStore<any> {
   selections: SelectorStubMap = {};
   subStores: SubStoreStubMap = {};
 
@@ -62,7 +62,7 @@ export class MockObservableStore<State> implements ObservableStore<null> {
     basePath: PathSelector,
     localReducer: Reducer<SubState>): MockObservableStore<SubState> =>
       this.initSubStore<SubState>(basePath)
-  
+
   getSubStore = (...pathSelectors: PathSelector[]): MockObservableStore<any> => {
     const [ first, ...rest ] = pathSelectors;
     return first ?


### PR DESCRIPTION
1) Reorganize interfaces internally to make sure MockNgRedux and NgRedux are structurally compatible (issue #419)
2) Fix a boundary condition where two instances of MockNgRedux could be created in certain cases.