### PR TITLE
Fixed a bug where subStores had issues with nonexistent base paths.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 6.5.3
+
+* Handle `@WithSubStore`, `.configureSubStore` boundary cases for when the base path
+doesn't exist in the store yet.
+
 # 6.5.2
 
 * Docgen updates.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@angular-redux/store",
-  "version": "6.5.2",
+  "version": "6.5.3",
   "description": "Angular 2 bindings for Redux",
   "main": "./lib/src/index.js",
   "scripts": {

--- a/src/components/selectors.ts
+++ b/src/components/selectors.ts
@@ -22,7 +22,7 @@ export const sniffSelectorType = <RootState, S>(selector?: Selector<RootState, S
 
 /** @hidden */
 export const resolver = <RootState, S>(selector?: Selector<RootState, S>) => ({
-  property: (state: any) => state[selector as PropertySelector],
+  property: (state: any) => state ? state[selector as PropertySelector] : undefined,
   path: (state: RootState) => getIn(state, selector as PathSelector),
   function: selector as FunctionSelector<RootState, S>,
   nil: (state: RootState) => state,

--- a/src/decorators/with-sub-store.spec.ts
+++ b/src/decorators/with-sub-store.spec.ts
@@ -128,6 +128,26 @@ describe('@WithSubStore', () => {
       // instance.
       expect(testInstance.obs$ === testInstance.obs$).toEqual(true);
     });
+
+    it('handle a base path with no extant store data', () => {
+      const iDontExistYetReducer =
+        (state: any, action: Action & { newValue: string }) =>
+          ({ ...state, nonexistentkey: action.newValue });
+
+      @WithSubStore({ basePathMethodName, localReducer: iDontExistYetReducer })
+      class TestClass {
+        @select('nonexistentkey') obs$: Observable<string>;
+        getSubStorePath = (): PathSelector => [ 'I', 'don\'t', 'exist', 'yet' ];
+        @dispatch() makeItExist = (newValue: string) => ({ type: 'nvm', newValue });
+      };
+
+      const testInstance = new TestClass();
+      testInstance.obs$
+        .take(2)
+        .toArray()
+        .subscribe(v => expect(v).toEqual([ undefined, 'now I exist' ]));
+      testInstance.makeItExist('now I exist');
+    });
   });
 
   describe('on the class causes @select$ to', () => {


### PR DESCRIPTION
Calling `.select` with PropertySelector would throw an exception in this case; however it
should return an observable with an initial value of undefined instead.