### PR TITLE
Adding a way for @dispatch methods to return a value that won't trigger a dispatch

### DIFF
--- a/src/components/ng-redux.ts
+++ b/src/components/ng-redux.ts
@@ -20,6 +20,13 @@ export abstract class NgRedux<RootState> implements ObservableStore<RootState> {
   static instance?: ObservableStore<any> = undefined;
 
   /**
+   * Provides a way for methods that use the @dispatch decorator to
+   * return a value that won't trigger a dispatch so they can conditionally
+   * dispatch based on any logic that suits the need
+   */
+  static readonly DISPATCH_NOOP = 'DISPATCH_NOOP';
+
+  /**
    * Configures a Redux store and allows NgRedux to observe and dispatch
    * to it.
    *

--- a/src/decorators/dispatch.spec.ts
+++ b/src/decorators/dispatch.spec.ts
@@ -108,7 +108,7 @@ describe('@dispatch', () => {
       ).toHaveBeenCalledWith(expectedArgs);
     });
 
-    it("shouldn't call dispatch", () => {
+    it('should not call dispatch', () => {
       const stateBeforeAction = NgRedux.instance && NgRedux.instance.getState();
       const result = instance.conditionalDispatchMethod(false);
       expect(result).toBe(false);

--- a/src/decorators/dispatch.ts
+++ b/src/decorators/dispatch.ts
@@ -17,15 +17,13 @@ export function dispatch(): PropertyDecorator {
 
     const wrapped = function (this: any, ...args: any[]) {
       const result = originalMethod.apply(this, args);
-      if (result === NgRedux.DISPATCH_NOOP) {
-        return result;
-      } else {
+      if (result !== NgRedux.DISPATCH_NOOP) {
         const store = getBaseStore(this) || NgRedux.instance;
         if (store) {
           store.dispatch(result);
         }
-        return result;
       }
+      return result;
     }
 
     descriptor = descriptor || Object.getOwnPropertyDescriptor(target, key);

--- a/src/decorators/dispatch.ts
+++ b/src/decorators/dispatch.ts
@@ -17,11 +17,15 @@ export function dispatch(): PropertyDecorator {
 
     const wrapped = function (this: any, ...args: any[]) {
       const result = originalMethod.apply(this, args);
-      const store = getBaseStore(this) || NgRedux.instance;
-      if (store) {
-        store.dispatch(result);
+      if (result === NgRedux.DISPATCH_NOOP) {
+        return result;
+      } else {
+        const store = getBaseStore(this) || NgRedux.instance;
+        if (store) {
+          store.dispatch(result);
+        }
+        return result;
       }
-      return result;
     }
 
     descriptor = descriptor || Object.getOwnPropertyDescriptor(target, key);


### PR DESCRIPTION
Adding a way for methods that use the `@dispatch` decorator to return a value that won't trigger a dispatch so they can conditionally dispatch based on any logic that suits the need. 

Currently returning anything but an action would cause middleware like redux-observable to throw or returning a mock action like `{ type: 'noop' }` would still activate the root reducer that, even though technically nothing will happen, just seems nicer that you can avoid all together the store.dispatch from within the same @dispatch-decorated method.

By having a specific value to allow this behaviour — rather than just using null or undefined — prevents accidental development errors of developers just forgetting to return.