### PR TITLE
Clarify Versioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,33 @@
+# 7.0.2 - Fixing Publish
+
+* There are no functional changes / fixes in this release. 
+
+There was accidental publish to the `@latest` tag with an expiremental fix for the v6 branch that got pushed out with the incorrect tag. 
+
+For some clarity:
+
+* v7+ - currently only works with Angular 5+
+* v6+ - works with Angular 4 and earlier, and v5. 
+* v8 - this was an accidental version bump - and that package is now deprecated.
+
+# Which Version to use?
+
+## Angular 5+
+
+Use `@angular-redux/store@^7` - this version supports Angular 5, and also changes to using lettable operators.
+
+Any new major releases will released on the v7 branch and with the `@latest` tag for final publishes. 
+
+## Angular 4 or lower 
+
+Use `@angular-redux/store@^6` - This supports Angular 4 and earlier.
+
+# Support for `@angular-redux/store@6`?
+
+Where possible, I will be maintaining and applying any fixes / enhancements for v7 into v6 where it does not introduce a breaking change.
+
+I made a few mistakes trying to publish fixes / etc to two major versions, which caused some releases to get tagged incorrectly and caused some confusion. Sorry for any confusion this has caused, and will do better on avoiding this in the future, and being more transparent with the releases that are going out.
+
 # 6.6.0 - Angular 5 Support 
 
 * Add Angular 5+ as peer dependency 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,22 @@
+
+# Which Version to use?
+
+## Angular 5+
+
+Use `@angular-redux/store@^7` - this version supports Angular 5, and also changes to using lettable operators.
+
+Any new major releases will released on the v7 branch and with the `@latest` tag for final publishes. 
+
+## Angular 4 or lower 
+
+Use `@angular-redux/store@^6` - This supports Angular 4 and earlier.
+
+# Support for `@angular-redux/store@6`?
+
+Where possible, I will be maintaining and applying any fixes / enhancements for v7 into v6 where it does not introduce a breaking change.
+
+I made a few mistakes trying to publish fixes / etc to two major versions, which caused some releases to get tagged incorrectly and caused some confusion. Sorry for any confusion this has caused, and will do better on avoiding this in the future, and being more transparent with the releases that are going out.
+
 # @angular-redux/store
 
 Angular bindings for [Redux](https://github.com/reactjs/redux).


### PR DESCRIPTION
# Which Version to use?

## Angular 5+

Use `@angular-redux/store@^7` - this version supports Angular 5, and also changes to using lettable operators.

Any new major releases will released on the v7 branch and with the `@latest` tag for final publishes.

## Angular 4 or lower

Use `@angular-redux/store@^6` - This supports Angular 4 and earlier.

# Support for `@angular-redux/store@6`?

Where possible, I will be maintaining and applying any fixes / enhancements for v7 into v6 where it does not introduce a breaking change.

I made a few mistakes trying to publish fixes / etc to two major versions, which caused some releases to get tagged incorrectly and caused some confusion. Sorry for any confusion this has caused, and will do better on avoiding this in the future, and being more transparent with the releases that are going out.