### PR TITLE
Add possibility to access component scope inside of 'transformer' function

### DIFF
--- a/src/components/selectors.ts
+++ b/src/components/selectors.ts
@@ -13,7 +13,8 @@ import { Observable } from 'rxjs/Observable';
  */
 export type Comparator = (x: any, y: any) => boolean;
 export type Transformer<RootState, V> = (
-  store$: Observable<RootState>
+  store$: Observable<RootState>,
+  scope: any
 ) => Observable<V>;
 export type PropertySelector = string | number | symbol;
 export type PathSelector = (string | number)[];

--- a/src/decorators/helpers.ts
+++ b/src/decorators/helpers.ts
@@ -173,7 +173,10 @@ export const getInstanceSelection = <T>(
         ? store.select(selector, comparator)
         : store
             .select(selector)
-            .pipe(obs$ => transformer(obs$, decoratedInstance), distinctUntilChanged(comparator)));
+            .pipe(
+              obs$ => transformer(obs$, decoratedInstance), 
+              distinctUntilChanged(comparator)
+            ));
 
     return selections[key];
   }

--- a/src/decorators/helpers.ts
+++ b/src/decorators/helpers.ts
@@ -173,7 +173,7 @@ export const getInstanceSelection = <T>(
         ? store.select(selector, comparator)
         : store
             .select(selector)
-            .pipe(transformer, distinctUntilChanged(comparator)));
+            .pipe(obs$ => transformer(obs$, decoratedInstance), distinctUntilChanged(comparator)));
 
     return selections[key];
   }

--- a/src/decorators/helpers.ts
+++ b/src/decorators/helpers.ts
@@ -174,7 +174,7 @@ export const getInstanceSelection = <T>(
         : store
             .select(selector)
             .pipe(
-              obs$ => transformer(obs$, decoratedInstance), 
+              obs$ => transformer(obs$, decoratedInstance),
               distinctUntilChanged(comparator)
             ));
 


### PR DESCRIPTION
This will allow to access any other property of component inside of transformation function, e.g:

```
@Input() public anotherInput: string;

@select$(['selector'], (obs$, inst) => obs$.filter(x => x.name === inst.anotherInput))
public selectedObs: Observable<any>;
```

Such changes, IMHO, is pretty easy and it has backward compatibility.